### PR TITLE
fix: handle cancel button (cancel_creation) to prevent 404 unhandled request

### DIFF
--- a/app/slack_app.py
+++ b/app/slack_app.py
@@ -8,6 +8,7 @@ from app.application.channel_creation_service import ChannelCreationService
 from app.channel_name_normalizer import normalize_channel_name
 from app.email_address_parser import parse_email_addresses
 from app.infrastructure.slack_client import SlackClient
+from app.presentation.constants import ACTION_IDS
 from app.presentation.error_messages import get_error_message_and_dm
 from app.presentation.modal_builder import (
     build_confirmation_modal,
@@ -198,6 +199,11 @@ def handle_confirmation_button(ack, action, body, client):
             sc.post_message(channel=user_id, text=error_message)
 
 
+def handle_cancel_button(ack, action, body, client):
+    """キャンセルボタンアクションハンドラー: 即時 ack のみ（挙動不変）。"""
+    ack()
+
+
 def create_app():
     """Slack Boltアプリケーションを作成"""
     app = App()
@@ -208,8 +214,9 @@ def create_app():
     # モーダル送信ハンドラー
     app.view("channel_creation_modal")(handle_modal_submission)
 
-    # 確認ボタンアクションハンドラー
-    app.action("confirm_creation")(handle_confirmation_button)
+    # 確認/キャンセル ボタンアクションハンドラー
+    app.action(ACTION_IDS["CONFIRM"])(handle_confirmation_button)
+    app.action(ACTION_IDS["CANCEL"])(handle_cancel_button)
 
     return app
 

--- a/tests/test_slack_app_interactions.py
+++ b/tests/test_slack_app_interactions.py
@@ -553,3 +553,20 @@ def test_channel_creator_deduplication_when_explicitly_specified():
     # 作成者が1回だけ含まれることを確認（重複しない）
     creator_count = user_ids.count("U123456")
     assert creator_count == 1
+
+
+def test_cancel_button_ack_only():
+    """キャンセルボタン: ack され、API呼び出しやモーダル更新は行われない"""
+    from app.slack_app import handle_cancel_button
+
+    ack = Mock()
+    client = Mock()
+    action = {"action_id": "cancel_creation"}
+    body = {"user": {"id": "U123456"}, "view": {"id": "V123456"}}
+
+    handle_cancel_button(ack=ack, action=action, body=body, client=client)
+
+    ack.assert_called_once()
+    client.views_update.assert_not_called()
+    client.conversations_create.assert_not_called()
+    client.conversations_invite.assert_not_called()


### PR DESCRIPTION
Fixes #10

目的 (WHY)
- 確認モーダルで「キャンセル」押下時の block_actions (`action_id: cancel_creation`) が未ハンドルで、Slack Bolt が 404 (unhandled request) を返し、モーダル右の『!』表示と WARNING ログが出ていた問題を解消します。

変更内容 (WHAT)
- 追加: `handle_cancel_button()` — `ack()` のみ実行するキャンセル用ハンドラ。
- 登録: `app.action(ACTION_IDS["CANCEL"])` を追加（キャンセルを確実にハンドリング）。
- 統一: 既存の confirm 登録も `ACTION_IDS["CONFIRM"]` に統一（文字列の直接指定を排除）。
- テスト: `test_cancel_button_ack_only` を追加（キャンセルで API 呼び出しが走らない／`ack()` されることを検証）。

挙動の変化 (BEFORE/AFTER)
- BEFORE: キャンセル押下 → 404 (unhandled request)／WARNING ログ／モーダルに『!』表示。
- AFTER: キャンセル押下 → 3 秒以内に `ack()`、追加処理なし。404/WARNING なし。UI の『!』非表示。

互換性・リスク (IMPACT)
- 既存の作成フロー（confirm のみ有効）はそのまま。キャンセル時の未ハンドルを解消するだけの変更で、外形仕様（文言・views_open/update 回数・DM送信）に影響はありません。リスク低。

テスト (TESTS)
- 追加 1 件を含め 49 tests GREEN。

実装詳細 (DETAILS)
- 定数: `ACTION_IDS` を使用して action_id の重複・記述ブレを予防。
- 最小修正: キャンセルはサーバ側の状態変更を行わないため `ack()` のみ。

関連 (LINKS)
- Issue: #10
