### PR TITLE
ux(cancel): '戻る'で入力画面へ、closeは『閉じる』に統一／UI定義をmodal_builderへ集約

### DIFF
--- a/app/presentation/modal_builder.py
+++ b/app/presentation/modal_builder.py
@@ -92,6 +92,7 @@ def build_confirmation_modal(
         "type": "modal",
         "callback_id": "channel_creation_confirmation",
         "title": {"type": "plain_text", "text": MODAL_TITLES["CONFIRM"]},
+        "close": {"type": "plain_text", "text": "キャンセル"},
         "private_metadata": private_metadata_json,
         "blocks": blocks,
     }

--- a/app/presentation/modal_builder.py
+++ b/app/presentation/modal_builder.py
@@ -9,7 +9,7 @@ def build_initial_modal() -> Dict[str, Any]:
         "callback_id": "channel_creation_modal",
         "title": {"type": "plain_text", "text": MODAL_TITLES["CREATE"]},
         "submit": {"type": "plain_text", "text": "確認する"},
-        "close": {"type": "plain_text", "text": "キャンセル"},
+        "close": {"type": "plain_text", "text": "閉じる"},
         "blocks": [
             {
                 "type": "input",
@@ -81,7 +81,7 @@ def build_confirmation_modal(
                 },
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": "キャンセル"},
+                    "text": {"type": "plain_text", "text": "戻る"},
                     "action_id": ACTION_IDS["CANCEL"],
                 },
             ],
@@ -92,7 +92,7 @@ def build_confirmation_modal(
         "type": "modal",
         "callback_id": "channel_creation_confirmation",
         "title": {"type": "plain_text", "text": MODAL_TITLES["CONFIRM"]},
-        "close": {"type": "plain_text", "text": "キャンセル"},
+        "close": {"type": "plain_text", "text": "閉じる"},
         "private_metadata": private_metadata_json,
         "blocks": blocks,
     }

--- a/app/slack_app.py
+++ b/app/slack_app.py
@@ -62,51 +62,7 @@ def handle_modal_submission(ack, view, client, body):
         sc.open_view(trigger_id=body["trigger_id"], view=build_error_modal(error_message))
         return
 
-    # 確認モーダルのブロックを構築
-    # 表示名のリストを生成
-    display_names = [user_info["display_name"] for user_info in user_info_list]
-    blocks = [
-        {"type": "section", "text": {"type": "mrkdwn", "text": f"*チャンネル名:* {channel_name}"}},
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"*招待するユーザー:*\n• {', '.join(display_names)}",
-            },
-        },
-    ]
-
-    # 見つからなかったメールアドレスがある場合は表示
-    if not_found_emails:
-        blocks.append(
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*見つからなかったメール:*\n• {', '.join(not_found_emails)}",
-                },
-            }
-        )
-
-    # 確認ボタンを追加
-    blocks.append(
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": "作成"},
-                    "action_id": "confirm_creation",
-                    "style": "primary",
-                },
-                {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": "キャンセル"},
-                    "action_id": "cancel_creation",
-                },
-            ],
-        }
-    )
+    # UIブロックの構築は modal_builder 側へ集約済み（重複を避けるためここでは組み立てない）
 
     # チャンネル情報をprivate_metadataに保存
     import json

--- a/app/slack_app.py
+++ b/app/slack_app.py
@@ -200,9 +200,14 @@ def handle_confirmation_button(ack, action, body, client):
 
 
 def handle_cancel_button(ack, action, body, client):
-    """キャンセルボタン: 確認画面 → 入力画面に戻す（モーダルを更新）。"""
-    # 入力用の初期モーダルに差し替え（Stackは維持しつつ画面を戻す）
-    ack(response_action="update", view=build_initial_modal())
+    """キャンセルボタン: 確認画面 → 入力画面に戻す（views.update を使用）。"""
+    # まず3秒以内にack
+    ack()
+    # その後、現在の view を初期モーダルに差し替え
+    view = body.get("view", {})
+    view_id = view.get("id")
+    if view_id:
+        SlackClient(client).update_view(view_id=view_id, view=build_initial_modal())
 
 
 def create_app():

--- a/app/slack_app.py
+++ b/app/slack_app.py
@@ -200,8 +200,9 @@ def handle_confirmation_button(ack, action, body, client):
 
 
 def handle_cancel_button(ack, action, body, client):
-    """キャンセルボタンアクションハンドラー: 即時 ack のみ（挙動不変）。"""
-    ack()
+    """キャンセルボタン: 確認画面 → 入力画面に戻す（モーダルを更新）。"""
+    # 入力用の初期モーダルに差し替え（Stackは維持しつつ画面を戻す）
+    ack(response_action="update", view=build_initial_modal())
 
 
 def create_app():

--- a/tests/test_presentation_modal_builder.py
+++ b/tests/test_presentation_modal_builder.py
@@ -23,8 +23,10 @@ def test_build_confirmation_modal_includes_channel_users_and_optionally_not_foun
     )
     assert view["type"] == "modal"
     assert view["callback_id"] == "channel_creation_confirmation"
-    # close ボタンが追加されたことを確認
-    assert view["close"]["text"] == "キャンセル"
+    # close ボタンは「閉じる」であること
+    assert view["close"]["text"] == "閉じる"
+    # アクション行のボタンには「戻る」が含まれること
+    assert "戻る" in str(view["blocks"])
     blocks_text = str(view["blocks"])
     assert "test-channel" in blocks_text
     assert "太郎" in blocks_text

--- a/tests/test_presentation_modal_builder.py
+++ b/tests/test_presentation_modal_builder.py
@@ -23,6 +23,8 @@ def test_build_confirmation_modal_includes_channel_users_and_optionally_not_foun
     )
     assert view["type"] == "modal"
     assert view["callback_id"] == "channel_creation_confirmation"
+    # close ボタンが追加されたことを確認
+    assert view["close"]["text"] == "キャンセル"
     blocks_text = str(view["blocks"])
     assert "test-channel" in blocks_text
     assert "太郎" in blocks_text

--- a/tests/test_slack_app_interactions.py
+++ b/tests/test_slack_app_interactions.py
@@ -556,7 +556,7 @@ def test_channel_creator_deduplication_when_explicitly_specified():
 
 
 def test_cancel_button_updates_modal_back_to_initial():
-    """キャンセルボタン: 入力モーダルに差し替える（response_action="update"）"""
+    """キャンセルボタン: 入力モーダルに差し替える（views_update を使う）"""
     from app.slack_app import handle_cancel_button
 
     ack = Mock()
@@ -566,13 +566,10 @@ def test_cancel_button_updates_modal_back_to_initial():
 
     handle_cancel_button(ack=ack, action=action, body=body, client=client)
 
-    # response_action="update" で入力モーダルが返ることを検証
-    assert ack.call_count == 1
-    kwargs = ack.call_args.kwargs
-    assert kwargs.get("response_action") == "update"
-    view = kwargs.get("view")
-    assert view and view.get("callback_id") == "channel_creation_modal"
-    # API呼び出しは行われない
-    client.views_update.assert_not_called()
+    # ack され、views_update が呼ばれることを検証
+    ack.assert_called_once()
+    client.views_update.assert_called_once()
+    args, kwargs = client.views_update.call_args
+    assert kwargs["view"]["callback_id"] == "channel_creation_modal"
     client.conversations_create.assert_not_called()
     client.conversations_invite.assert_not_called()


### PR DESCRIPTION
目的 (WHY)
- 確認モーダルのキャンセル動作を『戻る/閉じる』で明確化し、前画面に戻らない問題を解消。
- UI定義の重複（slack_app と modal_builder）を解消し、単一箇所に集約。

変更内容 (WHAT)
- handle_cancel_button: ack()→views.update で入力モーダルへ差し替え。
- ラベル統一: アクション行『戻る』、右下『閉じる』。
- slack_app から手組みUIを削除し、modal_builder に一本化。
- テスト更新: 戻るの挙動、ラベルを検証。49 passed。

挙動の変化 (BEFORE/AFTER)
- BEFORE: キャンセルで 404/『!』が出ることがある、画面が戻らない、ボタン名が同一。
- AFTER: 戻る=前画面、閉じる=モーダル終了。404/『!』なし。

互換性・影響
- 作成フロー本流に影響なし（UX改善と内部整頓）。
