### PR TITLE
fix(#13): エラーモーダルを views.update で表示（モバイルChromeで消える問題に対応）

### DIFF
--- a/app/slack_app.py
+++ b/app/slack_app.py
@@ -57,9 +57,15 @@ def handle_modal_submission(ack, view, client, body):
         else:
             error_message = f"ユーザー解決でエラーが発生しました: {str(e)}"
 
-        # エラーモーダルを表示（ビルダー）
+        # エラーモーダルに差し替え（view_submissionは update の方がクライアント間で安定）
         sc = SlackClient(client)
-        sc.open_view(trigger_id=body["trigger_id"], view=build_error_modal(error_message))
+        curr_view = body.get("view", {}) or view
+        view_id = curr_view.get("id")
+        if view_id:
+            sc.update_view(view_id=view_id, view=build_error_modal(error_message))
+        else:
+            # フォールバック（通常は到達しない）
+            sc.open_view(trigger_id=body["trigger_id"], view=build_error_modal(error_message))
         return
 
     # UIブロックの構築は modal_builder 側へ集約済み（重複を避けるためここでは組み立てない）

--- a/tests/test_slack_app_interactions.py
+++ b/tests/test_slack_app_interactions.py
@@ -409,16 +409,13 @@ def test_modal_submission_handles_all_users_not_found_error():
         # モーダル送信ハンドラーを実行
         handle_modal_submission(ack=ack, view=view, client=client, body=body)
 
-    # 期待結果：ack()が呼ばれ、エラーモーダルが表示される
+    # 期待結果：ack()が呼ばれ、モーダルがエラー表示に更新される（スマホでも安定）
     ack.assert_called_once()
-    client.views_open.assert_called_once()
+    client.views_update.assert_called_once()
 
     # エラーモーダルの内容検証
-    modal_call_args = client.views_open.call_args
-    call_kwargs = modal_call_args[1] if modal_call_args[1] else modal_call_args[0][0]
-
-    assert call_kwargs["trigger_id"] == "123456.987654.abcdef"
-    view_data = call_kwargs["view"]
+    update_call = client.views_update.call_args
+    view_data = update_call[1]["view"]
     assert "エラー" in view_data["title"]["text"]
     assert "見つかりませんでした" in str(view_data["blocks"])
 


### PR DESCRIPTION
問題
- 入力バリデーションで全員不在（AllUsersNotFoundError）のとき、エラーモーダルを views.open で表示していたため、Android 15 の Chrome 等でモーダルが消えるケースがあった。

対応
- handle_modal_submission のエラーパスを views.update に変更し、現在の view をエラー内容へ差し替え。
- テストを views_update 前提に更新（スマホでも安定）。

影響
- 挙動は『エラー表示』のまま（UXは不変）。デスクトップ/モバイル両方で安定表示。

テスト
- 49 passed。

closed #13 